### PR TITLE
Update BitVec to 1.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ categories = ["parsing"]
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-bitvec = "0.22.3"
+bitvec = "1.0.0"
 nom = { version = "7.0.0", default-features = false }
 
 [features]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,7 +8,7 @@
 //! let data = [0xA5u8, 0x69, 0xF0, 0xC3];
 //! let bits = data.view_bits::<Msb0>();
 //!
-//! fn parser(bits: &BitSlice<Msb0, u8>) -> IResult<&BitSlice<Msb0, u8>, &BitSlice<Msb0, u8>> {
+//! fn parser(bits: &BitSlice<u8, Msb0>) -> IResult<&BitSlice<u8, Msb0>, &BitSlice<u8, Msb0>> {
 //!   tag(bits![1, 0, 1, 0])(bits)
 //! }
 //!
@@ -20,5 +20,5 @@ mod input;
 
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
 #[repr(transparent)]
-pub struct BSlice<'a, O: BitOrder, T: BitStore>(pub &'a BitSlice<O, T>);
-pub struct BArray<O: BitOrder, T: BitStore>(pub BitArray<O, T>);
+pub struct BSlice<'a, T: BitStore, O: BitOrder>(pub &'a BitSlice<T, O>);
+pub struct BArray<T: BitStore, O: BitOrder>(pub BitArray<T, O>);

--- a/tests/bitstream.rs
+++ b/tests/bitstream.rs
@@ -11,7 +11,7 @@ fn parse_bitstream() {
     let data = [0xA5u8, 0x69, 0xF0, 0xC3];
     let bits = data.view_bits::<Msb0>();
 
-    fn parser(bits: BSlice<Msb0, u8>) -> IResult<BSlice<Msb0, u8>, BSlice<Msb0, u8>> {
+    fn parser(bits: BSlice<u8, Msb0>) -> IResult<BSlice<u8, Msb0>, BSlice<u8, Msb0>> {
         tag(BSlice(bits![1, 0, 1, 0]))(bits)
     }
 
@@ -26,8 +26,8 @@ fn parse_bitstream_map() {
     let data = [0b1000_0000];
     let bits = data.view_bits::<Msb0>();
 
-    fn parser(bits: BSlice<Msb0, u8>) -> IResult<BSlice<Msb0, u8>, bool> {
-        map(take(1_u8), |val: BSlice<Msb0, u8>| val[0])(bits)
+    fn parser(bits: BSlice<u8, Msb0>) -> IResult<BSlice<u8, Msb0>, bool> {
+        map(take(1_u8), |val: BSlice<u8, Msb0>| val[0])(bits)
     }
 
     assert_eq!(parser(BSlice(bits)), Ok((BSlice(&bits[1..]), true)));


### PR DESCRIPTION
This PR does what it says on the tin - BitVec is updated to the stabilised API. The bit storage and bit order type parameters have been swapped to match the upstream BitVec style (bit store type first, then bit order), and modified/removed unstable BitVec API calls have been replaced with their stable versions. All tests pass.